### PR TITLE
Added link libraries path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ FIND_PACKAGE(OpenCV REQUIRED)
 FIND_PACKAGE(CUDA REQUIRED)
 FIND_PACKAGE(Boost REQUIRED)
 
-
+link_directories(/usr/local/cuda/lib64/)
 
 
 ####################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ FIND_PACKAGE(OpenCV REQUIRED)
 FIND_PACKAGE(CUDA REQUIRED)
 FIND_PACKAGE(Boost REQUIRED)
 
-link_directories(/usr/local/cuda/lib64/)
+
 
 
 ####################################################################

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,9 +40,9 @@ target_link_libraries(darknet
         ${CUDA_LIBRARIES}
         pthread
         m
-        cudart
-        cublas
-        curand
+        ${CUDA_LIBRARIES}
+        ${CUDA_CUBLAS_LIBRARIES}
+        ${CUDA_curand_LIBRARY}
         )
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(darknetTest
         ${CUDA_LIBRARIES}
         pthread
         m
-        cudart
-        cublas
-        curand
+        ${CUDA_LIBRARIES}
+        ${CUDA_CUBLAS_LIBRARIES}
+        ${CUDA_curand_LIBRARY}
     )


### PR DESCRIPTION
Darknet was unable to link libcublas, libcudart and libcurand. I added link path for CMake.