### PR TITLE
Fixed Build errors regarding CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ FIND_PACKAGE(OpenCV REQUIRED)
 FIND_PACKAGE(CUDA REQUIRED)
 FIND_PACKAGE(Boost REQUIRED)
 
-
+link_directories(/usr/local/cuda/lib64/)
 
 
 ####################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ FIND_PACKAGE(OpenCV REQUIRED)
 FIND_PACKAGE(CUDA REQUIRED)
 FIND_PACKAGE(Boost REQUIRED)
 
-link_directories(/usr/local/cuda/lib64/)
+
 
 
 ####################################################################

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,9 +40,9 @@ target_link_libraries(darknet
         ${CUDA_LIBRARIES}
         pthread
         m
-        cudart
-        cublas
-        curand
+        ${CUDA_LIBRARIES}
+        ${CUDA_CUBLAS_LIBRARIES}
+        ${CUDA_curand_LIBRARY}
         )
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,7 +37,6 @@ target_link_libraries(darknet
         darknetExamplesLib
         darknetLib
         ${OpenCV_LIBRARIES}
-        ${CUDA_LIBRARIES}
         pthread
         m
         ${CUDA_LIBRARIES}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(darknetTest
         ${CUDA_LIBRARIES}
         pthread
         m
-        cudart
-        cublas
-        curand
+        ${CUDA_LIBRARIES}
+        ${CUDA_CUBLAS_LIBRARIES}
+        ${CUDA_curand_LIBRARY}
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,6 @@ target_link_libraries(darknetTest
         darknetAPILib
         darknetLib
         ${OpenCV_LIBRARIES}
-        ${CUDA_LIBRARIES}
         pthread
         m
         ${CUDA_LIBRARIES}


### PR DESCRIPTION
Cmake was not able to link ```cudart cublas``` and ```curand```, so I added their variables returned from ```FIND_PACKAGE(CUDA_REQUIRED)``` in target link libraries.